### PR TITLE
feat: Add minimal Next.js app scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# Testing
+/coverage
+
+# Next.js
+/.next/
+/out/
+
+# Production
+/build
+
+# Misc
+.DS_Store
+*.pem
+
+# Debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Local env files
+.env*.local
+
+# Vercel
+.vercel
+
+# TypeScript
+*.tsbuildinfo
+next-env.d.ts

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,88 @@
+* {
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+}
+
+html,
+body {
+  max-width: 100vw;
+  overflow-x: hidden;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.container {
+  padding: 6rem;
+  min-height: 100vh;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.hero code {
+  background: #fafafa;
+  border-radius: 5px;
+  padding: 0.3rem;
+  font-size: 1.1rem;
+  font-family: Menlo, Monaco, monospace;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  max-width: 800px;
+}
+
+.card {
+  padding: 1.5rem;
+  border: 1px solid #eaeaea;
+  border-radius: 10px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  text-decoration: none;
+  color: inherit;
+}
+
+.card:hover {
+  border-color: #0070f3;
+}
+
+.card h2 {
+  margin-bottom: 0.5rem;
+  font-size: 1.5rem;
+}
+
+.card p {
+  font-size: 1rem;
+  color: #666;
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 4rem 1rem;
+  }
+  
+  .hero h1 {
+    font-size: 2rem;
+  }
+  
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Test MCP Next.js App',
+  description: 'A minimal Next.js application scaffold',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,20 @@
+export default function Home() {
+  return (
+    <main className="container">
+      <div className="hero">
+        <h1>Welcome to Next.js</h1>
+        <p>Get started by editing <code>app/page.tsx</code></p>
+        <div className="grid">
+          <a href="https://nextjs.org/docs" className="card">
+            <h2>Documentation →</h2>
+            <p>Find in-depth information about Next.js features and API.</p>
+          </a>
+          <a href="https://nextjs.org/learn" className="card">
+            <h2>Learn →</h2>
+            <p>Learn about Next.js in an interactive course with quizzes!</p>
+          </a>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "test-mcp-nextjs",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
This PR adds a minimal Next.js application scaffold to address issue #6.

## What's included:
- ✅ Next.js 14 with TypeScript support
- ✅ Basic project structure (app directory)
- ✅ Essential dependencies (React, Next.js, TypeScript)
- ✅ Simple homepage component
- ✅ Next.js configuration (next.config.js)
- ✅ Basic responsive styling (CSS modules)
- ✅ Package.json scripts (dev/build/start)
- ✅ TypeScript configuration
- ✅ .gitignore for Next.js projects

## Usage
```bash
npm install
npm run dev
```

Visit `http://localhost:3000` to see the app.

## Files added:
- `package.json` - Dependencies and scripts
- `next.config.js` - Next.js configuration  
- `tsconfig.json` - TypeScript configuration
- `app/page.tsx` - Homepage component
- `app/layout.tsx` - Root layout
- `app/globals.css` - Global styles
- `.gitignore` - Git ignore rules

Fixes #6